### PR TITLE
Stop searching for log streams asynchronously to avoid rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
       - uses: actions/checkout@v1
       - name: make
         run: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
       - uses: actions/checkout@v1
       - name: make
         run: make

--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,16 @@ coverage: bin/.coverage.out
 	@go tool cover -html=bin/.coverage.out
 
 $(local_bins): bin/.fmtcheck bin/.vet bin/.coverage.out $(go_files)
-	CGO_ENABLED=0 go build -o $@ $(PACKAGE)/cmd/$(basename $(@F))
+	CGO_ENABLED=0 go build -trimpath -o $@ $(PACKAGE)/cmd/$(basename $(@F))
 
 $(mac_bins): bin/.fmtcheck bin/.vet bin/.coverage.out $(go_files)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $@ $(PACKAGE)/cmd/$(basename $(subst $(mac_suffix),,$(@F)))
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -o $@ $(PACKAGE)/cmd/$(basename $(subst $(mac_suffix),,$(@F)))
 
 $(linux_bins): bin/.fmtcheck bin/.vet bin/.coverage.out $(go_files)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ $(PACKAGE)/cmd/$(basename $(subst $(linux_suffix),,$(@F)))
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o $@ $(PACKAGE)/cmd/$(basename $(subst $(linux_suffix),,$(@F)))
 
 $(windows_bins): bin/.fmtcheck bin/.vet bin/.coverage.out $(go_files)
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o $@ $(PACKAGE)/cmd/$(basename $(subst $(windows_suffix),,$(@F)))
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -o $@ $(PACKAGE)/cmd/$(basename $(subst $(windows_suffix),,$(@F)))
 
 $(release_dir)sha256sums.txt: $(mac_bins) $(linux_bins) $(windows_bins)
 	@cd $(release_dir) && shasum -a 256 $(subst $(release_dir),,$^) > sha256sums.txt

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.30.23
 	github.com/deckarep/golang-set v1.7.1
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/tools v0.0.0-20191005014404-c9f9432ec4b2
 	gopkg.in/ini.v1 v1.55.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.30.9 h1:DntpBUKkchINPDbhEzDRin1eEn1TG9TZFlzWPf0i8to=
-github.com/aws/aws-sdk-go v1.30.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/aws/aws-sdk-go v1.30.12 h1:KrjyosZvkpJjcwMk0RNxMZewQ47v7+ZkbQDXjWsJMs8=
-github.com/aws/aws-sdk-go v1.30.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.30.23 h1:1Npeg2q6hicbrHoFu6MoeqZdcQf8187BI0VwKxEfLAY=
 github.com/aws/aws-sdk-go v1.30.23/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -50,6 +46,10 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
+github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=


### PR DESCRIPTION
Also:
* Bump to Go 1.14
* Enable reproducible builds