### PR TITLE
Restrict GitHub actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Perform release
+permissions:
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,6 @@
 name: Security Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Avoid potential supply-chain attacks by restricting what permissions the `GITHUB_TOKEN` has