### PR TITLE
Log messages during test to output

### DIFF
--- a/cmd/aws_finder/cloudfront_test.go
+++ b/cmd/aws_finder/cloudfront_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -103,8 +104,10 @@ func TestFindCloudFrontDistributions(t *testing.T) {
 			var buf bytes.Buffer
 
 			ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-				Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-				IgnoredAttributes: []string{"time"},
+				Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+					Level:       slog.LevelDebug,
+					ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+				}),
 			}))
 
 			err := findCloudFrontDistributions(ctx, test.needle, &distributions{test.distributions})

--- a/cmd/aws_finder/instance_test.go
+++ b/cmd/aws_finder/instance_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -183,8 +184,10 @@ func TestFindInstance(t *testing.T) {
 			var buf bytes.Buffer
 
 			ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-				Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-				IgnoredAttributes: []string{"time"},
+				Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+					Level:       slog.LevelDebug,
+					ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+				}),
 			}))
 
 			require.NoError(t, findInstances(ctx, test.needle, &instances{test.reservations}))

--- a/cmd/aws_finder/loggroup_test.go
+++ b/cmd/aws_finder/loggroup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -20,8 +21,10 @@ func TestFindLogGroup(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-		Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-		IgnoredAttributes: []string{"time"},
+		Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+			Level:       slog.LevelDebug,
+			ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+		}),
 	}))
 
 	require.NoError(t, findLogGroup(ctx, "find", &logGroups{

--- a/cmd/aws_finder/logstream_test.go
+++ b/cmd/aws_finder/logstream_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"testing"
 
@@ -20,8 +21,10 @@ func TestFindLogStream_AllLogGroups(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-		Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-		IgnoredAttributes: []string{"time"},
+		Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+			Level:       slog.LevelDebug,
+			ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+		}),
 	}))
 
 	require.NoError(t, findLogStream(ctx, nil, "find", &logStreams{
@@ -60,8 +63,10 @@ func TestFindLogStream_SpecificLogGroups(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-		Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-		IgnoredAttributes: []string{"time"},
+		Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+			Level:       slog.LevelDebug,
+			ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+		}),
 	}))
 
 	require.NoError(t, findLogStream(ctx, aws.String("expected-prefix"), "find", &logStreams{

--- a/cmd/aws_finder/main.go
+++ b/cmd/aws_finder/main.go
@@ -16,8 +16,11 @@ func main() {
 		Use: exeName,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := log.ContextWithLogger(cmd.Context(), slog.New(log.WithAttrsFromContextHandler{
-				Parent:            slog.NewTextHandler(cmd.OutOrStdout(), &slog.HandlerOptions{Level: logLevel.level}),
-				IgnoredAttributes: []string{"time"},
+				Parent: slog.NewTextHandler(cmd.ErrOrStderr(), &slog.HandlerOptions{
+					Level:       logLevel.level,
+					ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+					AddSource:   true,
+				}),
 			}))
 
 			cmd.SetContext(ctx)

--- a/cmd/aws_finder/s3_bucket_test.go
+++ b/cmd/aws_finder/s3_bucket_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"testing"
 
@@ -19,8 +20,10 @@ func TestFindS3Bucket(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-		Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-		IgnoredAttributes: []string{"time"},
+		Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+			Level:       slog.LevelDebug,
+			ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+		}),
 	}))
 
 	require.NoError(t, findS3Bucket(ctx, "find", &buckets{

--- a/cmd/aws_finder/tags_test.go
+++ b/cmd/aws_finder/tags_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -20,8 +21,10 @@ func TestFindByTag(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-		Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-		IgnoredAttributes: []string{"time"},
+		Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+			Level:       slog.LevelDebug,
+			ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+		}),
 	}))
 
 	require.NoError(t, findByTag(ctx, &resourceTagLister{

--- a/cmd/aws_finder/vpc_endpoint_service_test.go
+++ b/cmd/aws_finder/vpc_endpoint_service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"testing"
 
@@ -20,8 +21,10 @@ func TestFindVpcEndpointService(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-		Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-		IgnoredAttributes: []string{"time"},
+		Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+			Level:       slog.LevelDebug,
+			ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+		}),
 	}))
 
 	require.NoError(t, findVpcEndpointService(ctx, "find", &vpcEndpoints{

--- a/cmd/aws_finder/vpc_endpoint_test.go
+++ b/cmd/aws_finder/vpc_endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -102,8 +103,10 @@ func TestFindVpcEndpoints(t *testing.T) {
 			var buf bytes.Buffer
 
 			ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-				Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-				IgnoredAttributes: []string{"time"},
+				Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+					Level:       slog.LevelDebug,
+					ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+				}),
 			}))
 
 			err := findVpcEndpoints(ctx, test.needle, &vpcEndpointLister{test.endpoints})

--- a/cmd/aws_finder/vpc_test.go
+++ b/cmd/aws_finder/vpc_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -20,8 +21,10 @@ func TestFindVpc(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := log.ContextWithLogger(t.Context(), slog.New(log.WithAttrsFromContextHandler{
-		Parent:            slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
-		IgnoredAttributes: []string{"time"},
+		Parent: slog.NewTextHandler(io.MultiWriter(&buf, t.Output()), &slog.HandlerOptions{
+			Level:       slog.LevelDebug,
+			ReplaceAttr: log.FilterAttributesFromLog([]string{"time"}),
+		}),
 	}))
 
 	require.NoError(t, findVpc(ctx, "needle", &vpcs{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wjam/aws_finder
 
-go 1.24
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.37.1

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -3,8 +3,7 @@ package log
 import (
 	"context"
 	"log/slog"
-	"slices"
-	"time"
+	"strings"
 )
 
 type attrsKey struct{}
@@ -15,7 +14,7 @@ func WithAttrs(ctx context.Context, attr ...slog.Attr) context.Context {
 	if v := ctx.Value(attrsKey{}); v != nil {
 		existing = v.([]slog.Attr)
 	}
-	return context.WithValue(ctx, attrsKey{}, append(slices.Clone(existing), attr...))
+	return context.WithValue(ctx, attrsKey{}, append(existing, attr...))
 }
 
 func ContextWithLogger(ctx context.Context, logger *slog.Logger) context.Context {
@@ -29,8 +28,7 @@ func Logger(ctx context.Context) *slog.Logger {
 var _ slog.Handler = WithAttrsFromContextHandler{}
 
 type WithAttrsFromContextHandler struct {
-	Parent            slog.Handler
-	IgnoredAttributes []string
+	Parent slog.Handler
 }
 
 func (w WithAttrsFromContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
@@ -42,22 +40,7 @@ func (w WithAttrsFromContextHandler) Handle(ctx context.Context, record slog.Rec
 		record.AddAttrs(v.([]slog.Attr)...)
 	}
 
-	newRecord := slog.NewRecord(record.Time, record.Level, record.Message, record.PC)
-
-	if slices.Contains(w.IgnoredAttributes, "time") {
-		newRecord.Time = time.Time{}
-	}
-
-	record.Attrs(func(a slog.Attr) bool {
-		if slices.Contains(w.IgnoredAttributes, a.Key) {
-			return true
-		}
-
-		newRecord.AddAttrs(a)
-		return true
-	})
-
-	return w.Parent.Handle(ctx, newRecord)
+	return w.Parent.Handle(ctx, record)
 }
 
 func (w WithAttrsFromContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
@@ -66,4 +49,21 @@ func (w WithAttrsFromContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 
 func (w WithAttrsFromContextHandler) WithGroup(name string) slog.Handler {
 	return w.Parent.WithGroup(name)
+}
+
+func FilterAttributesFromLog(ignored []string) func(groups []string, a slog.Attr) slog.Attr {
+	lookup := make(map[string]struct{}, len(ignored))
+	for _, s := range ignored {
+		lookup[s] = struct{}{}
+	}
+	return func(groups []string, a slog.Attr) slog.Attr {
+		parts := append(groups, a.Key) //nolint:gocritic // two slices are semantically different
+		for i := 1; i <= len(parts); i++ {
+			key := strings.Join(parts[:i], ".")
+			if _, ok := lookup[key]; ok {
+				return slog.Attr{}
+			}
+		}
+		return a
+	}
 }

--- a/tools/golangci-lint/go.mod
+++ b/tools/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module github.com/wjam/flac-check/tools/golangci-lint
 
-go 1.24
+go 1.25
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 


### PR DESCRIPTION
Make it easier to diagnose issues by outputting log messages to test output.

Also bump to Go 1.25.